### PR TITLE
State and Killer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,7 @@ config :event_bus,
 config :event_bus_logger,
   enabled: {:system, "EB_LOGGER_ENABLED", "true"},
   level: {:system, "EB_LOGGER_LEVEL", :info},
-  topics: {:system, "EB_LOGGER_TOPICS", "shopiexrl_store_events"},
+  topics: {:system, "EB_LOGGER_TOPICS", ".*"},
   light_logging: {:system, "EB_LOGGER_LIGHT", "false"}
 
 import_config "#{Mix.env}.exs"

--- a/lib/shopiexrl/guards.ex
+++ b/lib/shopiexrl/guards.ex
@@ -1,0 +1,43 @@
+defmodule ShopiexRL.Guards do
+  @moduledoc """
+  Guards used in the ShopiexRL OTP application
+  """
+
+  @doc """
+  Checks if `count` is greater than `cap`
+  """
+  defmacro at_cap?(count, rate_cap) do
+    quote do
+      unquote(count) > unquote(rate_cap)
+    end
+  end
+
+  @doc """
+  Checks if `count` is less than `cap`
+  """
+  defmacro below_cap?(count, rate_cap) do
+    quote do
+      unquote(count) < unquote(rate_cap)
+    end
+  end
+
+  @doc """
+  Checks if incrementing by `increment_rate` will overflow `cap`
+  """
+
+  defmacro will_overfill?(count, incr_rate, rate_cap) do
+    quote do
+      unquote(count) + unquote(incr_rate) > unquote(rate_cap)
+    end
+  end
+
+  @doc """
+  Checks if decrementing by `increment_rate` will make `cap` negative
+  """
+  defmacro will_underfill?(count, leak_rate) do
+    quote do
+      unquote(count) < unquote(leak_rate)
+    end
+  end
+
+end

--- a/lib/shopiexrl/state/store.ex
+++ b/lib/shopiexrl/state/store.ex
@@ -1,0 +1,9 @@
+defmodule State.Store do
+  @type t :: %__MODULE__{
+          name: String.t(),
+          count: integer(),
+          rates: State.StoreRates.t(),
+          killdown: integer()
+        }
+  defstruct [:name, :count, :rates, :killdown]
+end

--- a/lib/shopiexrl/state/store_rates.ex
+++ b/lib/shopiexrl/state/store_rates.ex
@@ -1,0 +1,12 @@
+defmodule State.StoreRates do
+  @type t :: %__MODULE__{
+          increment_rate: integer(),
+          leak_rate: integer(),
+          leak_interval: integer(),
+          cap: integer()
+        }
+  defstruct increment_rate: 1,
+            leak_rate: 2,
+            leak_interval: 500,
+            cap: 20
+end

--- a/lib/shopiexrl/store.ex
+++ b/lib/shopiexrl/store.ex
@@ -1,111 +1,162 @@
 defmodule ShopiexRL.Store do
   use GenServer
-
-  @base_increment_rate 1
-  @base_leak_rate 2
-  @base_leak_interval 500
-  @base_size 20
+  import ShopiexRL.Guards
 
   @spec start_link({store_name :: any(), initial_count :: any()}) :: any()
   def start_link({name, initial_count}) do
     GenServer.start_link(
       __MODULE__,
-      {name, initial_count},
+      %State.Store{name: name, count: initial_count, rates: store_rates_provider(1)},
       name: name
     )
   end
 
-  @spec init({store_name :: any(), initial_count :: any()}) :: any()
-  def init({name, initial_count}) do
+  def init(state_obj) do
     ShopiexRL.event(:shopiexrl_store_events, %{
-      name: name,
-      count: initial_count,
+      state: state_obj,
       type: :boot
     })
 
     send(self(), :leak)
 
-    {:ok, %{name: name, count: initial_count}}
+    {:ok, state_obj}
   end
 
-  @spec handle_call(:health_check, pid(), %{count: any(), name: any()}) :: tuple()
-  def handle_call(:health_check, _from, %{count: count, name: name})
-      when count + @base_increment_rate > @base_size do
+  def handle_call(:health_check, _from, state_obj), do: health_check(state_obj)
+  def handle_call(:increment, _from, state_obj), do: increment(state_obj)
+  def handle_info(:leak, state_obj), do: leak(state_obj)
+
+  ##  -------------------
+  ## Private
+  ##  -------------------
+
+  # Health check when the bucket is full
+  defp health_check(%State.Store{
+    count: count,
+    rates: %State.StoreRates{
+      increment_rate: increment_rate,
+      cap: cap
+    }
+  } = state_obj) when will_overfill?(count, increment_rate, cap) do
     ShopiexRL.event(:shopiexrl_store_events, %{
-      name: name,
-      count: count,
+      state: state_obj,
       type: :health_check,
       response: :backoff
     })
 
-    {:reply, :backoff, %{count: count, name: name}}
+    {:reply, :backoff, state_obj}
   end
 
-  @spec handle_call(:health_check, pid(), %{count: any(), name: any()}) :: tuple()
-  def handle_call(:health_check, _from, %{count: count, name: name}) do
+  # default health check
+  defp health_check(state_obj) do
     ShopiexRL.event(:shopiexrl_store_events, %{
-      name: name,
-      count: count,
+      state: state_obj,
       type: :health_check,
       response: :ok
     })
 
-    {:reply, :ok, %{count: count, name: name}}
+    {:reply, :ok, state_obj}
   end
 
-  @spec handle_call(:increment, pid(), %{count: any(), name: any()}) :: tuple()
-  def handle_call(:increment, _from, %{count: count, name: name})
-      when count + @base_increment_rate > @base_size do
+  # Increment when bucket is already full
+  defp increment(%State.Store{
+    count: count,
+    rates: %State.StoreRates{
+      increment_rate: increment_rate,
+      cap: cap
+    }
+  } = state_obj) when will_overfill?(count, increment_rate, cap) do
     ShopiexRL.event(:shopiexrl_store_events, %{
-      name: name,
-      count: count,
+      state: state_obj,
       type: :increment,
       response: :too_many_requests
     })
 
-    {:reply, :too_many_requests, %{count: count, name: name}}
+    {:reply, :too_many_requests, state_obj}
   end
 
-  @spec handle_call(:increment, pid(), %{count: any(), name: any()}) :: tuple()
-  def handle_call(:increment, _from, %{count: count, name: name}) do
+  # Default increment event
+  defp increment(%State.Store{ } = state_obj) do
+    next_state = increase_count(state_obj)
+
     ShopiexRL.event(:shopiexrl_store_events, %{
-      name: name,
-      count: count,
-      next_count: count + @base_increment_rate,
+      state: state_obj,
+      next_state: next_state,
       type: :increment,
       response: :ok
     })
 
-    {:reply, count + @base_increment_rate, %{count: count + @base_increment_rate, name: name}}
+    {:reply, next_state, state_obj}
   end
 
-  @spec handle_info(:leak, %{count: any(), name: any()}) :: tuple()
-  def handle_info(:leak, %{count: count, name: name}) when count < @base_leak_rate do
+  # Leak when `leak_rate` is greater than `count`,
+  # set count to just `0`
+  defp leak(%State.Store{
+    count: count,
+    rates: %State.StoreRates{
+      leak_interval: leak_interval,
+      leak_rate: leak_rate
+    }
+  } = state_obj) when will_underfill?(count, leak_rate) do
+    next_state = empty_count(state_obj)
+
     ShopiexRL.event(:shopiexrl_store_leak_events, %{
-      name: name,
-      count: count,
-      next_count: 0,
+      state: state_obj,
+      next_state: next_state,
       type: :leak,
       response: :ok
     })
 
-    Process.send_after(self(), :leak, @base_leak_interval)
-
-    {:noreply, %{count: 0, name: name}}
+    Process.send_after(self(), :leak, leak_interval)
+    {:noreply, next_state}
   end
 
-  @spec handle_info(:leak, %{count: any(), name: any()}) :: tuple()
-  def handle_info(:leak, %{count: count, name: name}) do
+  # Default leak event
+  defp leak(%State.Store{rates: %State.StoreRates{leak_interval: leak_interval}} = state_obj) do
+    next_state = decrease_count(state_obj)
+
     ShopiexRL.event(:shopiexrl_store_leak_events, %{
-      name: name,
-      count: count,
-      next_count: count - @base_leak_rate,
+      state: state_obj,
+      next_state: next_state,
       type: :leak,
       response: :ok
     })
 
-    Process.send_after(self(), :leak, @base_leak_interval)
+    Process.send_after(self(), :leak, leak_interval)
+    {:noreply, next_state}
+  end
 
-    {:noreply, %{count: count - @base_leak_rate, name: name}}
+  #  ==================================
+  #  State Providers and Modifiers
+  #  ==================================
+  defp store_rates_provider(multiplier \\ 1) do
+    %State.StoreRates {
+      increment_rate: 1,
+      leak_rate: 2 * multiplier,
+      leak_interval: 500,
+      cap: 20 * multiplier
+    }
+  end
+
+  defp increase_count(%State.Store{
+    count: count,
+    rates: %State.StoreRates{
+      increment_rate: increment_rate
+    }
+  } = state_obj) do
+    Map.put(state_obj, :count, (count + increment_rate))
+  end
+
+  defp decrease_count(%State.Store{
+    count: count,
+    rates: %State.StoreRates{
+      leak_rate: leak_rate
+    }
+  } = state_obj) do
+    Map.put(state_obj, :count, (count - leak_rate))
+  end
+
+  defp empty_count(%State.Store{ } = state_obj) do
+    Map.put(state_obj, :count, 0)
   end
 end


### PR DESCRIPTION
Uses a state struct to store `count` and `killdown` as well as its rates parameters via `rates`.